### PR TITLE
Enabled link as an email address

### DIFF
--- a/dnstwister/templates/www/email/subscribe.html
+++ b/dnstwister/templates/www/email/subscribe.html
@@ -49,7 +49,7 @@
                         We've tried really hard to make our emails as clear
                         and as free of noise as possible but if there's
                         anything you think we could be doing better
-                        <a href="hello@dnstwister.report">please let us know</a>.
+                        <a href="mailto:hello@dnstwister.report">please let us know</a>.
 
                     </p>
                 </section>


### PR DESCRIPTION
Was previously appending email address to the end of report subscription url on click.